### PR TITLE
Added sanity checking and logging for missing VC runtime.

### DIFF
--- a/Xbim.Geometry.Engine.Interop/Xbim.Geometry.Engine.Interop.csproj
+++ b/Xbim.Geometry.Engine.Interop/Xbim.Geometry.Engine.Interop.csproj
@@ -65,9 +65,11 @@
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
+    <Compile Include="XbimArchitectureConventions.cs" />
     <Compile Include="XbimCustomAssemblyResolver.cs" />
     <Compile Include="XbimGeometryEngine.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="XbimPrerequisitesValidator.cs" />
   </ItemGroup>
   <Target Name="TouchFiles">
     <Touch ForceTouch="True" Files="XbimGeometryEngine.cs">
@@ -91,6 +93,7 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Xbim.Geometry.Engine.Interop/Xbim.Geometry.Engine.Interop.csproj
+++ b/Xbim.Geometry.Engine.Interop/Xbim.Geometry.Engine.Interop.csproj
@@ -65,6 +65,7 @@
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
+    <Compile Include="XbimCustomAssemblyResolver.cs" />
     <Compile Include="XbimGeometryEngine.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -98,19 +99,23 @@
     <Reference Include="System.Xml" />
     <Reference Include="Xbim.Common, Version=3.0.5625.38218, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Common.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.Ifc.Extensions, Version=3.0.5625.38220, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Ifc.Extensions.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.Ifc2x3, Version=3.0.5625.38218, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Ifc2x3.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.IO, Version=3.0.5625.38221, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.IO.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Xbim.Geometry.Engine.Interop/XbimArchitectureConventions.cs
+++ b/Xbim.Geometry.Engine.Interop/XbimArchitectureConventions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xbim.Geometry.Engine.Interop
+{
+
+    /// <summary>
+    /// A class representing the conventions we use for processor specific Geometry Engine library
+    /// </summary>
+    internal class XbimArchitectureConventions
+    {
+        public XbimArchitectureConventions()
+        {
+            if (Is64BitProcess())
+            {
+                Suffix = "64";
+                SubFolder = "x64";
+            }
+            else
+            {
+                Suffix = "32";
+                SubFolder = "x86";
+            }
+        }
+           
+        /// <summary>
+        /// The suffix we apply to platform-specific assemblys in the current process architecture
+        /// </summary>
+        public string Suffix { get; private set; }
+        /// <summary>
+        /// The default subfolder to look for platform-specific assemblys in the current process architecture
+        /// </summary>
+        public string SubFolder { get; private set; }
+
+        public static bool Is64BitProcess()
+        {
+            return (IntPtr.Size == 8);
+        }
+    }
+}

--- a/Xbim.Geometry.Engine.Interop/XbimCustomAssemblyResolver.cs
+++ b/Xbim.Geometry.Engine.Interop/XbimCustomAssemblyResolver.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Xbim.Common.Logging;
+
+namespace Xbim.Geometry.Engine.Interop
+{
+    internal class XbimCustomAssemblyResolver
+    {
+        internal const string GeomModuleName = "Xbim.Geometry.Engine";
+        internal const string XbimModulePrefix = "Xbim.";
+
+        internal static Assembly ResolverHandler(object sender, ResolveEventArgs args)
+        {
+            return LoadFile(args.Name);
+        }
+
+        private static Assembly LoadFile(string moduleName)
+        {
+            Assembly assembly = Assembly.GetExecutingAssembly(); // in the Interop asm
+            var codepath = new Uri(assembly.CodeBase); // code path always points to the deployed DLL
+
+            // Unlike Location codepath is a URI [file:\\c:\wwwroot\etc\WebApp\bin\Xbim.Geometry.Engine.Interop.dll]
+            // presumably because it could be Clickonce, Silverlight or run off UNC path
+            var appDir = Path.GetDirectoryName(codepath.LocalPath);
+
+
+            // var app2Dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if (appDir == null)
+                return null;
+
+            string libraryPath = null;
+
+            if (moduleName.StartsWith(GeomModuleName))
+            {
+                // Here we detect the type of CPU architecture 
+                // at runtime and select the mixed-mode library 
+                // from the corresponding directory.
+                // This approach assumes that we only have two 
+                // versions of the mixed mode assembly, 
+                // X86 and X64, it will not work however on 
+                // ARM-based applications or any other non X86/X64 
+                // platforms
+                var relativeDir = String.Format("{0}{1}.dll",
+                    GeomModuleName, (IntPtr.Size == 8) ? "64" : "32");
+
+                libraryPath = Path.Combine(appDir, (IntPtr.Size == 8) ? "x64" : "x86", relativeDir);
+
+                //if the engine file doesn't exist it is quite possible that the path is virtual
+                //but physical subdirectory might still exist.
+                if (!File.Exists(libraryPath))
+                    libraryPath = Path.Combine(IntPtr.Size == 8 ? "x64" : "x86", relativeDir);
+            }
+            else if (moduleName.StartsWith(XbimModulePrefix) && !moduleName.Contains("resources"))
+            {
+                // If the *32.dll or *64.dll is loaded from a
+                // subdirectory (e.g. plugins folder), .net can
+                // fail to resolve its dependencies so this is
+                // to give it a helping hand
+                var splitName = moduleName.Split(',');
+                if (splitName.Length >= 1)
+                {
+                    libraryPath = Path.Combine(appDir, splitName[0] + ".dll");
+                }
+            }
+
+            if (libraryPath != null)
+            {
+                LoggerFactory.GetLogger().Debug("Resolved assembly to: " + libraryPath);
+                Assembly geomLoaded = Assembly.LoadFile(libraryPath);
+                return geomLoaded;
+            }
+            return null;
+        }
+    }
+}

--- a/Xbim.Geometry.Engine.Interop/XbimGeometryEngine.cs
+++ b/Xbim.Geometry.Engine.Interop/XbimGeometryEngine.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Reflection;
 using System.Runtime.Remoting;
 
 using Xbim.Common.Geometry;
@@ -17,80 +16,15 @@ namespace Xbim.Geometry.Engine.Interop
 {  
     public class XbimGeometryEngine : IXbimGeometryCreator
     {
-        internal const string GeomModuleName = "Xbim.Geometry.Engine"; 
-        internal const string XbimModulePrefix = "Xbim.";
-
+        
         private readonly IXbimGeometryCreator _engine;
+        
         static XbimGeometryEngine()
         {
-         
-            AppDomain.CurrentDomain.AssemblyResolve += ResolverHandler;
+            // We need to wire in a custom assembly resolver since Xbim.Geometry.Engine is 
+            // not located using standard probing rules (due to way we deploy processor specific binaries)
+            AppDomain.CurrentDomain.AssemblyResolve += XbimCustomAssemblyResolver.ResolverHandler;
         }
-
-
-        private static Assembly ResolverHandler(object sender, ResolveEventArgs args)
-        {
-            return LoadFile(args.Name);
-        }
-
-        private static Assembly LoadFile(string moduleName)
-        {
-            Assembly assembly = Assembly.GetExecutingAssembly(); // in the Interop asm
-            var codepath = new Uri(assembly.CodeBase); // code path always points to the deployed DLL
-
-            // Unlike Location codepath is a URI [file:\\c:\wwwroot\etc\WebApp\bin\Xbim.Geometry.Engine.Interop.dll]
-            // presumably because it could be Clickonce, Silverlight or run off UNC path
-            var appDir = Path.GetDirectoryName(codepath.LocalPath);
-
-
-           // var app2Dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            if (appDir == null)
-                return null;
-
-            string libraryPath = null;
-
-            if (moduleName.StartsWith(GeomModuleName))
-            {
-                // Here we detect the type of CPU architecture 
-                // at runtime and select the mixed-mode library 
-                // from the corresponding directory.
-                // This approach assumes that we only have two 
-                // versions of the mixed mode assembly, 
-                // X86 and X64, it will not work however on 
-                // ARM-based applications or any other non X86/X64 
-                // platforms
-                var relativeDir = String.Format("{0}{1}.dll",
-                    GeomModuleName, (IntPtr.Size == 8) ? "64" : "32");
-
-                libraryPath = Path.Combine(appDir, (IntPtr.Size == 8) ? "x64" : "x86", relativeDir);
-
-                //if the engine file doesn't exist it is quite possible that the path is virtual
-                //but physical subdirectory might still exist.
-                if (!File.Exists(libraryPath))
-                    libraryPath = Path.Combine(IntPtr.Size == 8 ? "x64" : "x86", relativeDir);
-            }
-            else if (moduleName.StartsWith(XbimModulePrefix) && !moduleName.Contains("resources"))
-            {
-                // If the *32.dll or *64.dll is loaded from a
-                // subdirectory (e.g. plugins folder), .net can
-                // fail to resolve its dependencies so this is
-                // to give it a helping hand
-                var splitName = moduleName.Split(',');
-                if (splitName.Length >= 1)
-                {
-                    libraryPath = Path.Combine(appDir, splitName[0] + ".dll");
-                }
-            }
-
-            if (libraryPath != null)
-            {
-                LoggerFactory.GetLogger().Debug("Resolved assembly to: " + libraryPath);
-                Assembly geomLoaded =  Assembly.LoadFile(libraryPath);
-                return geomLoaded;
-            }
-            return null;
-        }
-
        
         public XbimGeometryEngine()
         {

--- a/Xbim.Geometry.Engine.Interop/XbimGeometryEngine.cs
+++ b/Xbim.Geometry.Engine.Interop/XbimGeometryEngine.cs
@@ -16,20 +16,26 @@ namespace Xbim.Geometry.Engine.Interop
 {  
     public class XbimGeometryEngine : IXbimGeometryCreator
     {
-        
+
         private readonly IXbimGeometryCreator _engine;
-        
+
         static XbimGeometryEngine()
         {
             // We need to wire in a custom assembly resolver since Xbim.Geometry.Engine is 
             // not located using standard probing rules (due to way we deploy processor specific binaries)
             AppDomain.CurrentDomain.AssemblyResolve += XbimCustomAssemblyResolver.ResolverHandler;
         }
-       
+
         public XbimGeometryEngine()
         {
-           
-            ObjectHandle oh = Activator.CreateInstance("Xbim.Geometry.Engine","Xbim.Geometry.XbimGeometryCreator");
+
+            // Warn if runtime for Engine is not present
+            XbimPrerequisitesValidator.Validate();
+
+            var conventions = new XbimArchitectureConventions();    // understands the process we run under
+            string assemblyName = "Xbim.Geometry.Engine" + conventions.Suffix;
+
+            ObjectHandle oh = Activator.CreateInstance(assemblyName, "Xbim.Geometry.XbimGeometryCreator");
             _engine = oh.Unwrap() as IXbimGeometryCreator;   
         }
         public IXbimGeometryObject Create(IfcGeometricRepresentationItem ifcRepresentation)

--- a/Xbim.Geometry.Engine.Interop/XbimPrerequisitesValidator.cs
+++ b/Xbim.Geometry.Engine.Interop/XbimPrerequisitesValidator.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xbim.Common.Logging;
+
+namespace Xbim.Geometry.Engine.Interop
+{
+    internal class XbimPrerequisitesValidator
+    {
+
+        static readonly ILogger Logger = LoggerFactory.GetLogger();
+        const string PrequisitesKey = "SuppressVCRuntimeWarning";
+
+        // Key under HKLM that indicates that VC12 runtime has been installed
+        const string vc12RuntimeRegistryKey = @"SOFTWARE\Microsoft\DevDiv\VC\Servicing\12.0";
+        const string vc12Download = @"https://www.microsoft.com/en-us/download/details.aspx?id=40784";
+
+        internal static void Validate()
+        {
+            // Check that the VC 12 runtime has been installed before invoking the native Geometry Engine
+            // to pre-empt issues resolving the native assembly.
+            var key = Registry.LocalMachine.OpenSubKey(vc12RuntimeRegistryKey);
+            if (key == null)
+            {
+                string message = String.Format("The Visual C++ runtime 'VC12' (VS2013) could not be located. This is required for XBim Geometry generation. Please install this from {0} ",
+                        vc12Download);
+                if (SuppressPrequisiteErrors())
+                {
+                    Logger.Warn(message);
+                }
+                else
+                {
+                    message += String.Format("\n\nTo suppress this exception define an AppSetting with key of '{0}' and value of 'true' in app.config", PrequisitesKey);
+                    throw new InvalidOperationException(message);
+                }
+            }
+
+        }
+
+        private static bool SuppressPrequisiteErrors()
+        {
+            bool isSuppressed = false;
+            var keyValue = System.Configuration.ConfigurationManager.AppSettings[PrequisitesKey];
+
+            if (keyValue != null)
+            {
+                bool.TryParse(keyValue, out isSuppressed);
+            }
+
+            return isSuppressed;
+        }
+    }
+}

--- a/Xbim.Geometry.Engine.Tests/App.config
+++ b/Xbim.Geometry.Engine.Tests/App.config
@@ -8,23 +8,15 @@
   <log4net>
     <!-- Defines default logging behaviour -->
     <root>
-      <!-- By default all loggers system-wide will output to the appender called 'ColoredConsoleAppender' and also 'DefaultLogFile' -->
-      <appender-ref ref="ColoredConsoleAppender" />
-      <appender-ref ref="DefaultLogFile" />
+      <appender-ref ref="console" />
       <!-- Set the default logging level to one of ALL DEBUG INFO WARN ERROR FATAL NONE -->
-      <level value="INFO" />
+      <level value="ALL" />
     </root>
-    <logger name="Xbim">
-      <!-- For Loggers in the Xbim Namespace, also output to an XML appender (enables a tool such as L4NDash to parse the output) -->
-      <appender-ref ref="XmlFile" />
-    </logger>
-    <appender name="DefaultLogFile" type="log4net.Appender.FileAppender">
-      <file type="log4net.Util.PatternString" value="XbimConvert.log" />
-      <appendToFile value="true" />
-      <layout type="log4net.Layout.PatternLayout">
-        <param name="ConversionPattern" value="%date %-5level [%identity] %type.%method: %message %newline %exception" />
+    <appender name="console" type="log4net.Appender.ConsoleAppender, log4net">
+      <layout type="log4net.Layout.PatternLayout,log4net">
+        <param name="ConversionPattern" value="%d [%t] %-5p %c - %m%n" />
       </layout>
-    </appender>&gt;
+    </appender>
     <!-- A xml-format rolling file appender, which creates a new file every hour or ah 100MB. This file can be consumed by a tool such as L4NDash --><appender name="XmlFile" type="log4net.Appender.RollingFileAppender"><file type="log4net.Util.PatternString" value="%property{LogName}_Default.xml" /><appendToFile value="true" /><rollingStyle value="Date" /><datePattern value=".yyyyMMdd" /><maxSizeRollBackups value="10" /><maximumFileSize value="100MB" /><staticLogFileName value="true" /><layout type="log4net.Layout.XmlLayout"><param name="Prefix" value="" /><locationInfo value="true" /></layout></appender><appender name="ColoredConsoleAppender" type="log4net.Appender.ColoredConsoleAppender"><mapping><level value="FATAL" /><foreColor value="White" /><backColor value="Red" /></mapping><mapping><level value="ERROR" /><foreColor value="Red, HighIntensity" /></mapping><mapping><level value="WARN" /><foreColor value="Green, HighIntensity" /></mapping><mapping><level value="INFO" /><foreColor value="Blue, HighIntensity" /></mapping><mapping><level value="DEBUG" /><foreColor value="White" /></mapping><layout type="log4net.Layout.PatternLayout"><conversionPattern value="%-5level - %message  [%logger %type.%method Line %line]%newline" /></layout></appender></log4net>
   
   <entityFramework>

--- a/Xbim.Geometry.Engine.Tests/Xbim.Geometry.Engine.Tests.csproj
+++ b/Xbim.Geometry.Engine.Tests/Xbim.Geometry.Engine.Tests.csproj
@@ -193,19 +193,23 @@
     <Reference Include="System" />
     <Reference Include="Xbim.Common, Version=3.0.5625.38218, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Common.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.Ifc.Extensions, Version=3.0.5625.38220, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Ifc.Extensions.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.Ifc2x3, Version=3.0.5625.38218, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Ifc2x3.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.IO, Version=3.0.5625.38221, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.IO.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Xbim.Geometry.Engine.Tests/Xbim.Geometry.Engine.Tests.csproj
+++ b/Xbim.Geometry.Engine.Tests/Xbim.Geometry.Engine.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="IfcProfileDefTests.cs" />
     <Compile Include="SurfaceSweepTests.cs" />
     <Compile Include="SceneTests.cs" />
+    <Compile Include="XbimAssemblyResolving.cs" />
     <Compile Include="WholeModelTests.cs" />
     <Compile Include="XbimFacetedMeshTests.cs" />
     <Compile Include="XbimGeometryToIfcTests.cs" />
@@ -194,22 +195,22 @@
     <Reference Include="Xbim.Common, Version=3.0.5625.38218, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Common.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Xbim.Ifc.Extensions, Version=3.0.5625.38220, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Ifc.Extensions.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Xbim.Ifc2x3, Version=3.0.5625.38218, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Ifc2x3.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Xbim.IO, Version=3.0.5625.38221, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.IO.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Xbim.Geometry.Engine.Tests/XbimAssemblyResolving.cs
+++ b/Xbim.Geometry.Engine.Tests/XbimAssemblyResolving.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GeometryTests
+{
+    [TestClass]
+    public class XbimAssemblyResolving
+    {
+        [TestMethod]
+        public void Invoking_Geometry_Engine_Should_Work()
+        {
+            var interopEngine = new Xbim.Geometry.Engine.Interop.XbimGeometryEngine();
+            // We're not expecting an exception
+            Assert.IsNotNull(interopEngine);
+            
+        }
+    }
+}

--- a/Xbim.Geometry.Profiler/Xbim.Geometry.Profiler.csproj
+++ b/Xbim.Geometry.Profiler/Xbim.Geometry.Profiler.csproj
@@ -59,19 +59,23 @@
     <Reference Include="System.Xml" />
     <Reference Include="Xbim.Common, Version=3.0.5625.38218, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Common.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.Ifc.Extensions, Version=3.0.5625.38220, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Ifc.Extensions.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.Ifc2x3, Version=3.0.5625.38218, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Ifc2x3.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.IO, Version=3.0.5625.38221, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.IO.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Xbim.Geometry.Regression/XbimRegression.csproj
+++ b/Xbim.Geometry.Regression/XbimRegression.csproj
@@ -87,19 +87,23 @@
     <Reference Include="System.Core" />
     <Reference Include="Xbim.Common, Version=3.0.5625.38218, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Common.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.Ifc.Extensions, Version=3.0.5625.38220, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Ifc.Extensions.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.Ifc2x3, Version=3.0.5625.38218, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Ifc2x3.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.IO, Version=3.0.5625.38221, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.IO.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Xbim.ModelGeometry.Scene/Xbim.ModelGeometry.Scene.csproj
+++ b/Xbim.ModelGeometry.Scene/Xbim.ModelGeometry.Scene.csproj
@@ -68,19 +68,23 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Xbim.Common, Version=3.0.5625.38218, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Common.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.Ifc.Extensions, Version=3.0.5625.38220, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Ifc.Extensions.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.Ifc2x3, Version=3.0.5625.38218, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.Ifc2x3.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xbim.IO, Version=3.0.5625.38221, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.Essentials.3.0.23\lib\net45\Xbim.IO.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
2nd attempt at PR - this time without the line-ending changes so should be a simpler merge

Apart from fixing some assembly resolving issues with Specific Version, the main changes should provide more diagnostics when dependencies of the Geometry Engine dll can't be located (by checking the registry for a well known VC runtime key)


1. XbimAssemblyResolver has been factored out of Interop/Xbim.GeometryEngine
2. Some of the 'magic' conventions (paths, suffixes) have been moved to a dedicated class XbimArchitectureConventions
3. Check for a registry key left by the VC12 installer to establish that the C++ Redistributable 12 has been installed.
4. If it hasn't throw an exception with instructions on the download, and abort loading the engine
5. This behaviour can be overridden with AppSetting (SuppressVCRuntimeWarning=true) degrading the exception to a logged warning. Mainly in case I've missed something - setting is detailed in the exception
6. There was a bug where it was not possible to resolve the suffixed Engine dll out of the bin folder because we relied on assembly resolver to do the mapping to 32/64 versions, and that only looked in x86/x64 folders. Not supporting the default deployment seems un-intuitive. Rather than overload the special handler I made Interop/XbimGeometryEngine smart enough to ask for the correct assemblyname based on what Process arch we're running in, so that standard resolving will work.