### PR TITLE
Random unhandled exceptions creating wire geometry

### DIFF
--- a/Xbim.Geometry.Engine/XbimWire.cpp
+++ b/Xbim.Geometry.Engine/XbimWire.cpp
@@ -64,6 +64,9 @@
 #include <GProp_GProps.hxx>
 #include <GC_MakeSegment.hxx>
 #include <ShapeAnalysis_Wire.hxx>
+
+#include <msclr\lock.h>
+
 using namespace Xbim::Common;
 using namespace System::Linq;
 namespace Xbim
@@ -253,7 +256,16 @@ namespace Xbim
 
 			BRepOffsetAPI_MakeOffset offseter(centreWire);
 			Standard_Real offset = profile->Thickness / 2;
-			offseter.Perform(offset);
+
+			// Pyatkov 15.06.2017.
+			// Somewhere in the BRepOffsetAPI_MakeOffset.Perform() a static variable is used:
+			// static BRepMAT2d_Explorer Exp;
+			// That is why calls to this function in a multi-threaded mode (as it is in Xbim) 
+			// lead to an unpredictable behavior.
+			{
+				msclr::lock l(_makeOffsetLock);
+				offseter.Perform(offset);
+			} //destructor of lock is called (lock is released).
 			
 			double precision = profile->Model->ModelFactors->Precision;
 			if (offseter.IsDone() && offseter.Shape().ShapeType() == TopAbs_WIRE)

--- a/Xbim.Geometry.Engine/XbimWire.h
+++ b/Xbim.Geometry.Engine/XbimWire.h
@@ -18,6 +18,8 @@ namespace Xbim
 		ref class XbimWire : IXbimWire, XbimOccShape
 		{
 		private:
+			// Lock for preventing a usage of BRepOffsetAPI_MakeOffset.Perform(...) in a multi-threaded mode.
+			static Object^ _makeOffsetLock = gcnew Object();
 
 			IntPtr ptrContainer;
 			virtual property TopoDS_Wire* pWire


### PR DESCRIPTION
Multi-threaded usage of OCC function BRepOffsetAPI_MakeOffset.Perform()
leads to an Unpredictable behavior and unhandled native access violation
exceptions. That is because function BRepOffsetAPI_MakeOffset.Perform()
uses static BRepMAT2d_Explorer Exp, so it should not be used in a
multi-threaded mode.
As a solution I have wrapped this call in a thread lock.