### PR TITLE
Fixing issue #92 and refactoring boolean solid operations

### DIFF
--- a/Xbim.Geometry.Engine.Interop/XbimGeometryEngine.cs
+++ b/Xbim.Geometry.Engine.Interop/XbimGeometryEngine.cs
@@ -90,14 +90,14 @@ namespace Xbim.Geometry.Engine.Interop
             return _engine.CreateSolid(ifcSolid);
         }
 
-        public IXbimSolid CreateSolid(IIfcBooleanClippingResult ifcSolid)
+        public IXbimSolidSet CreateSolidSet(IIfcBooleanClippingResult ifcSolid)
         {
-            return _engine.CreateSolid(ifcSolid);
+            return _engine.CreateSolidSet(ifcSolid);
         }
 
-        public IXbimSolid CreateSolid(IIfcBooleanOperand ifcSolid)
+        public IXbimSolidSet CreateSolidSet(IIfcBooleanOperand ifcSolid)
         {
-            return _engine.CreateSolid(ifcSolid);
+            return _engine.CreateSolidSet(ifcSolid);
         }
 
         public IXbimSolid CreateSolid(IIfcHalfSpaceSolid ifcSolid)
@@ -140,9 +140,9 @@ namespace Xbim.Geometry.Engine.Interop
             return _engine.CreateSolid(ifcSolid);
         }
 
-        public IXbimSolid CreateSolid(IIfcCsgSolid ifcSolid)
+        public IXbimSolidSet CreateSolidSet(IIfcCsgSolid ifcSolid)
         {
-            return _engine.CreateSolid(ifcSolid);
+            return _engine.CreateSolidSet(ifcSolid);
         }
 
         public IXbimSolid CreateSolid(IIfcSphere ifcSolid)

--- a/Xbim.Geometry.Engine/XbimGeometryCreator.cpp
+++ b/Xbim.Geometry.Engine/XbimGeometryCreator.cpp
@@ -203,9 +203,9 @@ namespace Xbim
 				}				
 				else if (dynamic_cast<IIfcCsgSolid^>(geomRep))
 				{
-					XbimSolid^ solid = (XbimSolid^)CreateSolid((IIfcCsgSolid^)geomRep);
-					if (objectLocation != nullptr) solid->Move(objectLocation);
-					return solid;
+					XbimSolidSet^ solidSet = (XbimSolidSet^)CreateSolidSet((IIfcCsgSolid^)geomRep);
+					if (objectLocation != nullptr) solidSet->Move(objectLocation);
+					return Trim(solidSet);
 				}
 				else if (dynamic_cast<IIfcSphere^>(geomRep))
 				{
@@ -504,25 +504,25 @@ namespace Xbim
 			return gcnew XbimSolid(IIfcSolid);
 		};
 
-		IXbimSolid^ XbimGeometryCreator::CreateSolid(IIfcBooleanResult^ IIfcSolid)
+		IXbimSolidSet^ XbimGeometryCreator::CreateSolidSet(IIfcBooleanResult^ IIfcSolid)
 		{
-			return gcnew XbimSolid(IIfcSolid);
+			return gcnew XbimSolidSet(IIfcSolid);
 		};
 
-		IXbimSolid^ XbimGeometryCreator::CreateSolid(IIfcBooleanOperand^ IIfcSolid)
+		IXbimSolidSet^ XbimGeometryCreator::CreateSolidSet(IIfcBooleanOperand^ IIfcSolid)
 		{
 			//ensure operands get treated correctly
 			if (dynamic_cast<IIfcBooleanClippingResult^>(IIfcSolid))
-				return gcnew XbimSolid((IIfcBooleanClippingResult^)IIfcSolid);
+				return gcnew XbimSolidSet((IIfcBooleanClippingResult^)IIfcSolid);
 			else if(dynamic_cast<IIfcBooleanResult^>(IIfcSolid))
-				return gcnew XbimSolid((IIfcBooleanResult^)IIfcSolid);
+				return gcnew XbimSolidSet((IIfcBooleanResult^)IIfcSolid);
 			else if (dynamic_cast<IIfcSolidModel^>(IIfcSolid))
-				return gcnew XbimSolid((IIfcSolidModel^)IIfcSolid);
+				return gcnew XbimSolidSet(gcnew XbimSolid((IIfcSolidModel^)IIfcSolid));
 			else if (dynamic_cast<IIfcHalfSpaceSolid^>(IIfcSolid))
-				return gcnew XbimSolid((IIfcHalfSpaceSolid^)IIfcSolid);
+				return gcnew XbimSolidSet(gcnew XbimSolid((IIfcHalfSpaceSolid^)IIfcSolid));
 			else if (dynamic_cast<IIfcCsgPrimitive3D^>(IIfcSolid))
-				return gcnew XbimSolid((IIfcCsgPrimitive3D^)IIfcSolid);
-			return gcnew XbimSolid(IIfcSolid);
+				return gcnew XbimSolidSet(gcnew XbimSolid((IIfcCsgPrimitive3D^)IIfcSolid));
+			return gcnew XbimSolidSet(IIfcSolid);
 		};
 		
 		IXbimSolid^ XbimGeometryCreator::CreateSolid(IIfcBooleanClippingResult^ IIfcSolid)
@@ -530,7 +530,10 @@ namespace Xbim
 			return gcnew XbimSolid(IIfcSolid);
 		};
 
-		
+		IXbimSolidSet^ XbimGeometryCreator::CreateSolidSet(IIfcBooleanClippingResult^ IIfcSolid)
+		{
+			return gcnew XbimSolidSet(IIfcSolid);
+		};
 
 		IXbimSolid^ XbimGeometryCreator::CreateSolid(IIfcHalfSpaceSolid^ IIfcSolid)
 		{
@@ -573,9 +576,9 @@ namespace Xbim
 			return gcnew XbimSolid(IIfcSolid);
 		};
 
-		IXbimSolid^ XbimGeometryCreator::CreateSolid(IIfcCsgSolid^ IIfcSolid)
+		IXbimSolidSet^ XbimGeometryCreator::CreateSolidSet(IIfcCsgSolid^ IIfcSolid)
 		{
-			return gcnew XbimSolid(IIfcSolid);
+			return gcnew XbimSolidSet(IIfcSolid);
 		};
 
 		IXbimSolid^ XbimGeometryCreator::CreateSolid(IIfcSphere^ IIfcSolid)
@@ -647,11 +650,6 @@ namespace Xbim
 		{
 			return gcnew XbimShell(linExt);
 		}
-
-		IXbimSolidSet^ XbimGeometryCreator::CreateSolidSet(IIfcBooleanResult^ boolOp)
-		{
-			return gcnew XbimSolidSet(boolOp);
-		};
 
 #pragma endregion
 
@@ -834,7 +832,8 @@ namespace Xbim
 				return;
 			}
 		}
-
+		// TODO Remove?
+		/*
 		IXbimSolidSet^ XbimGeometryCreator::CreateBooleanResult(IIfcBooleanClippingResult^ clip)
 		{
 			IModelFactors^ mf = clip->Model->ModelFactors;
@@ -933,7 +932,7 @@ namespace Xbim
 				return xbimSolidSet;
 		}
 
-#pragma endregion
+#pragma endregion */
 #pragma region Support for curves
 		IXbimCurve^ XbimGeometryCreator::CreateCurve(IIfcCurve^ curve)
 		{

--- a/Xbim.Geometry.Engine/XbimGeometryCreator.h
+++ b/Xbim.Geometry.Engine/XbimGeometryCreator.h
@@ -107,12 +107,15 @@ namespace Xbim
 			virtual IXbimSolid^ CreateSolid(IIfcBoundingBox^ ifcSolid);
 			virtual IXbimSolid^ CreateSolid(IIfcSurfaceCurveSweptAreaSolid^ ifcSolid);
 
-			virtual IXbimSolid^ CreateSolid(IIfcBooleanResult^ ifcSolid);
 			virtual IXbimSolid^ CreateSolid(IIfcBooleanClippingResult^ ifcSolid);
-			virtual IXbimSolid^ CreateSolid(IIfcBooleanOperand^ ifcSolid);
 			virtual IXbimSolid^ CreateSolid(IIfcHalfSpaceSolid^ ifcSolid);
 			virtual IXbimSolid^ CreateSolid(IIfcPolygonalBoundedHalfSpace^ ifcSolid);
 			virtual IXbimSolid^ CreateSolid(IIfcBoxedHalfSpace^ ifcSolid);
+
+			virtual IXbimSolidSet^ CreateSolidSet(IIfcBooleanOperand^ ifcSolid);
+			virtual IXbimSolidSet^ CreateSolidSet(IIfcBooleanResult^ ifcSolid);
+			virtual IXbimSolidSet^ CreateSolidSet(IIfcBooleanClippingResult^ ifcSolid);
+			virtual IXbimSolidSet^ CreateSolidSet(IIfcCsgSolid^ ifcSolid);
 
 			virtual IXbimSolidSet^ CreateSolidSet(IIfcManifoldSolidBrep^ ifcSolid);
 			virtual IXbimSolidSet^ CreateSolidSet(IIfcFacetedBrep^ ifcSolid);
@@ -123,7 +126,6 @@ namespace Xbim
 			virtual IXbimSolidSet^ CreateSolidSet(IIfcRevolvedAreaSolid^ ifcSolid);
 			virtual IXbimSolidSet^ CreateSolidSet(IIfcSurfaceCurveSweptAreaSolid^ ifcSolid);
 			virtual IXbimSolid^ CreateSolid(IIfcCsgPrimitive3D^ ifcSolid);
-			virtual IXbimSolid^ CreateSolid(IIfcCsgSolid^ ifcSolid);
 			virtual IXbimSolid^ CreateSolid(IIfcSphere^ ifcSolid);
 			virtual IXbimSolid^ CreateSolid(IIfcBlock^ ifcSolid);
 			virtual IXbimSolid^ CreateSolid(IIfcRightCircularCylinder^ ifcSolid);
@@ -140,10 +142,9 @@ namespace Xbim
 			virtual void WriteTriangulation(BinaryWriter^ bw, IXbimGeometryObject^ shape, double tolerance, double deflection, double angle);
 
 			virtual IIfcFacetedBrep^ CreateFacetedBrep(Xbim::Common::IModel^ model, IXbimSolid^ solid);
+		
 			//Creates collections of objects
 			virtual IXbimSolidSet^ CreateSolidSet();
-			virtual IXbimSolidSet^ CreateSolidSet(IIfcBooleanResult^ boolOp);
-			virtual IXbimSolidSet^ CreateBooleanResult(IIfcBooleanClippingResult^ clip);
 			virtual IXbimGeometryObjectSet^ CreateGeometryObjectSet();
 
 			//Ifc4 interfaces

--- a/Xbim.Geometry.Engine/XbimSolid.h
+++ b/Xbim.Geometry.Engine/XbimSolid.h
@@ -45,14 +45,12 @@ namespace Xbim
 			void Init(IIfcHalfSpaceSolid^ solid, double maxExtrusion, XbimPoint3D centroid);
 			void Init(IIfcBoxedHalfSpace^ solid);
 			void Init(IIfcPolygonalBoundedHalfSpace^ solid, double maxExtrusion);
-			void Init(IIfcBooleanResult^ solid);
 			void Init(IIfcBooleanClippingResult^ solid);
 			void Init(IIfcBooleanOperand^ solid);
 			void Init(XbimRect3D rect3D, double tolerance);
 
 			void Init(IIfcFixedReferenceSweptAreaSolid^ IIfcSolid, IIfcProfileDef^ overrideProfileDef);
 			void Init(IIfcCsgPrimitive3D^ IIfcSolid);
-			void Init(IIfcCsgSolid^ IIfcSolid);
 			void Init(IIfcSphere^ IIfcSolid);
 			void Init(IIfcBlock^ IIfcSolid);
 			void Init(IIfcRightCircularCylinder^ IIfcSolid);

--- a/Xbim.Geometry.Engine/XbimSolidSet.h
+++ b/Xbim.Geometry.Engine/XbimSolidSet.h
@@ -26,13 +26,14 @@ namespace Xbim
 		private:
 			List<IXbimSolid^>^ solids;
 			static XbimSolidSet^ empty = gcnew XbimSolidSet();
+			void Init(IIfcBooleanOperand^ boolOp);
 			void Init(IIfcBooleanResult^ boolOp);
 			void Init(XbimCompound^ comp, IPersistEntity^ ent);
 			void Init(IIfcSweptAreaSolid^ solid);
 			void Init(IIfcExtrudedAreaSolid^ solid);
 			void Init(IIfcSurfaceCurveSweptAreaSolid^ IIfcSolid);
 			void Init(IIfcRevolvedAreaSolid^ solid);
-			
+			void Init(IIfcCsgSolid^ IIfcSolid);
 
 			static VolumeComparer^ _volumeComparer = gcnew VolumeComparer();
 			static int _maxOpeningsToCut = 100;
@@ -57,7 +58,8 @@ namespace Xbim
 			XbimSolidSet(XbimCompound^ shape);
 			XbimSolidSet(IXbimSolid^ solid);
 			XbimSolidSet(IEnumerable<IXbimSolid^>^ solids);
-			XbimSolidSet(IIfcBooleanResult^ boolOp);
+			XbimSolidSet(IIfcBooleanOperand^ boolOp);
+			XbimSolidSet(IIfcCsgSolid^ csgSolid);
 			XbimSolidSet(IIfcManifoldSolidBrep^ solid);
 			XbimSolidSet(IIfcFacetedBrep^ solid);
 			XbimSolidSet(IIfcFacetedBrepWithVoids^ solid);
@@ -68,7 +70,6 @@ namespace Xbim
 			XbimSolidSet(IIfcExtrudedAreaSolid^ solid);
 			XbimSolidSet(IIfcRevolvedAreaSolid^ solid);
 			
-
 			virtual property bool IsValid {bool get() { return solids != nullptr && this != XbimSolidSet::Empty; }; }
 			virtual property bool IsSimplified{bool get(){ return _isSimplified; }; void set(bool val){ _isSimplified = val; } }
 			virtual property bool IsSet{bool get()  { return true; }; }


### PR DESCRIPTION
Fixes the CSG operation problem of more complex CSG trees with multiple solid outcomes (initially labeled as repeated elements).

Reference https://github.com/xBimTeam/XbimGeometry/issues/92