### PR TITLE
Fix #145 Not rendering IfcTriangulatedFaceSet correctly ( but other IFC viewers can) 

### DIFF
--- a/Xbim.ModelGeometry.Scene/Xbim3DModelContext.cs
+++ b/Xbim.ModelGeometry.Scene/Xbim3DModelContext.cs
@@ -410,13 +410,12 @@ namespace Xbim.ModelGeometry.Scene
                     //we can only handle one representation in a context and this is in an implementers agreement
                     if (product.Representation != null)
                     {
-                        if (product.Representation.Representations == null) continue;
-                        var rep =
-                            product.Representation.Representations.FirstOrDefault(
-                                r => Contexts.Contains(r.ContextOfItems) &&
-                                     r.IsBodyRepresentation());
-                        //write out the representation if it has one
-                        if (rep != null)
+                        if (product.Representation.Representations == null)
+                            continue;
+
+                        // Write product representations of context
+                        foreach (var rep in product.Representation.Representations.Where(
+                                    r => (!Contexts.Any() || Contexts.Contains(r.ContextOfItems)) && r.IsBodyRepresentation()))
                         {
                             foreach (var shape in rep.Items.Where(i => !(i is IIfcGeometricSet)))
                             {
@@ -956,9 +955,8 @@ namespace Xbim.ModelGeometry.Scene
                 if (product.Representation.Representations == null)
                     return;
 
-                var rep = product.Representation.Representations.FirstOrDefault(r => IsInContext(r) && r.IsBodyRepresentation());
-                //write out the representation if it has one
-                if (rep != null)
+                // Write product representations of context
+                foreach (var rep in product.Representation.Representations.Where(r => IsInContext(r) && r.IsBodyRepresentation()))
                 {
                     WriteProductShape(contextHelper, product, true, txn);
                 }
@@ -997,9 +995,7 @@ namespace Xbim.ModelGeometry.Scene
             if (product.Representation.Representations == null)
                 return Enumerable.Empty<XbimShapeInstance>();
 
-            var rep = product.Representation.Representations.FirstOrDefault(r => IsInContext(r) && r.IsBodyRepresentation());
-            if (rep == null)
-                return Enumerable.Empty<XbimShapeInstance>();
+            var reps = product.Representation.Representations.Where(r => IsInContext(r) && r.IsBodyRepresentation());
 
             // logic to classify feature tagging
             var repType = includesOpenings
@@ -1013,10 +1009,9 @@ namespace Xbim.ModelGeometry.Scene
 
             // transform setup
             var placementTransform = XbimPlacementTree.GetTransform(product, contextHelper.PlacementTree, Engine);
-            
+
             // process the items
-            var shapesInstances = WriteProductShapeRepresentationItems(contextHelper, product, txn, rep, repType, placementTransform, rep.Items);
-            return shapesInstances;
+            return reps.SelectMany(r => WriteProductShapeRepresentationItems(contextHelper, product, txn, r, repType, placementTransform, r.Items));
         }
 
         private List<XbimShapeInstance> WriteProductShapeRepresentationItems(XbimCreateContextHelper contextHelper, IIfcProduct product, IGeometryStoreInitialiser txn, IIfcRepresentation rep, XbimGeometryRepresentationType repType, XbimMatrix3D placementTransform, IItemSet<IIfcRepresentationItem> representationItems)

--- a/Xbim.ModelGeometry.Scene/Xbim3DModelContext.cs
+++ b/Xbim.ModelGeometry.Scene/Xbim3DModelContext.cs
@@ -419,8 +419,7 @@ namespace Xbim.ModelGeometry.Scene
                         {
                             foreach (var shape in rep.Items.Where(i => !(i is IIfcGeometricSet)))
                             {
-                                var mappedItem = shape as IIfcMappedItem;
-                                if (mappedItem != null)
+                                if (shape is IIfcMappedItem mappedItem)
                                 {
                                     ProcessMappedItem(isFeatureElementShape, isVoidedProductShape, mappedItem);
                                 }
@@ -956,7 +955,7 @@ namespace Xbim.ModelGeometry.Scene
                     return;
 
                 // Write product representations of context
-                foreach (var rep in product.Representation.Representations.Where(r => IsInContext(r) && r.IsBodyRepresentation()))
+                if(product.Representation.Representations.Any(r => IsInContext(r) && r.IsBodyRepresentation()))
                 {
                     WriteProductShape(contextHelper, product, true, txn);
                 }
@@ -1010,8 +1009,8 @@ namespace Xbim.ModelGeometry.Scene
             // transform setup
             var placementTransform = XbimPlacementTree.GetTransform(product, contextHelper.PlacementTree, Engine);
 
-            // process the items
-            return reps.SelectMany(r => WriteProductShapeRepresentationItems(contextHelper, product, txn, r, repType, placementTransform, r.Items));
+            // process the items and evaluate here
+            return reps.SelectMany(r => WriteProductShapeRepresentationItems(contextHelper, product, txn, r, repType, placementTransform, r.Items)).ToList();
         }
 
         private List<XbimShapeInstance> WriteProductShapeRepresentationItems(XbimCreateContextHelper contextHelper, IIfcProduct product, IGeometryStoreInitialiser txn, IIfcRepresentation rep, XbimGeometryRepresentationType repType, XbimMatrix3D placementTransform, IItemSet<IIfcRepresentationItem> representationItems)


### PR DESCRIPTION
I've created a clean PR (I fought against the VS/msbuild mysterious dependency managemant - why doesn't Microsoft use gradle or sbt???? :-). 

Indeed, the problem was a silent assumption that only a single representation with a unique context exists per product. The example provides multiple representations. Now it works - but looks a little bit ugly, since some color information is missing (or not set correctly in the IFC model as already stated)