### PR TITLE
Fixes #95 Exception Creating IfcGrid

### DIFF
--- a/Xbim.Geometry.Engine/XbimGeometryCreator.cpp
+++ b/Xbim.Geometry.Engine/XbimGeometryCreator.cpp
@@ -1193,12 +1193,12 @@ namespace Xbim
 					failedGridLines = true;
 					String^ err = gcnew String(ex.what());
 					LogWarning(logger, grid, "Grid axis #"+ curveWithTag->Item1.ToString() +" caused exception. " + err);
-					return solids;
+					failedGridLines = true;
 				}
 				catch (...)
 				{
 					LogWarning(logger, grid, "Grid axis "+ curveWithTag->Item1.ToString() + " caused internal exception. ");
-					return solids;
+					failedGridLines = true;
 				}
 					
 			}


### PR DESCRIPTION
There are two issues:
- If there's no intersection of IfcGridAxis curves, the empty bounding box causes an early break
- The default tolerance of the pipe maker utility of OCC causes trouble with already trimmed lines

Another uncovered issue is the a bug in grid representation. The visual bounds computation doesn't consider grids.
