### PR TITLE
Make IsBodyRepresentation check more strict

### DIFF
--- a/Xbim.ModelGeometry.Scene/Extensions/IIfcRepresentationExtensions.cs
+++ b/Xbim.ModelGeometry.Scene/Extensions/IIfcRepresentationExtensions.cs
@@ -13,8 +13,7 @@ namespace Xbim.ModelGeometry.Scene.Extensions
         /// <returns></returns>
         public static bool IsBodyRepresentation(this IIfcRepresentation rep)
         {
-            //in old models sometimes the representation is not defined so assume it is a candidate
-            if (string.IsNullOrEmpty(rep.RepresentationIdentifier)) return true;
+            if (string.IsNullOrEmpty(rep.RepresentationIdentifier)) return false;
             string repIdentifier = rep.RepresentationIdentifier.Value;
             //if it is defined as body then it is candidate but exclude if it is using a line base representation
             if (String.Compare(repIdentifier, "body", StringComparison.OrdinalIgnoreCase) == 0 || String.Compare(repIdentifier, "facetation", StringComparison.OrdinalIgnoreCase) == 0)


### PR DESCRIPTION
Make IsBodyRepresentation check of geometry shapes more strict. This fixes the issue of gettings wrong unnecessary boundingBox geometries for the models linked below.
http://openifcmodel.cs.auckland.ac.nz/Model/Details/182
http://openifcmodel.cs.auckland.ac.nz/Model/Details/208
Also this seems to be the cause of https://github.com/xBimTeam/XbimWindowsUI/issues/123
I'm not aware of any downsides to this change.