### PR TITLE
Better handling of exceptions in XbimGeometryCreator

### DIFF
--- a/Xbim.Geometry.Engine.Interop.Tests/Xbim.Geometry.Engine.Interop.Tests.csproj
+++ b/Xbim.Geometry.Engine.Interop.Tests/Xbim.Geometry.Engine.Interop.Tests.csproj
@@ -7,6 +7,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\XbimOpenSourceKeyFile.snk</AssemblyOriginatorKeyFile>
     
+    
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -27,9 +28,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Xbim.Geometry.Engine.Interop.build.targets
+++ b/Xbim.Geometry.Engine.Interop.build.targets
@@ -15,7 +15,7 @@
   ******************************************************************************
   -->
 
-  <ItemGroup Condition=" '$(Platform)' == 'x86'">
+  <ItemGroup Condition=" '$(Platform)' == 'x86' OR '$(Platform)' == 'AnyCPU'">
     <XbimInteropFiles Condition="'$(MSBuildThisFileDirectory)' != '' And
                                    HasTrailingSlash('$(MSBuildThisFileDirectory)')"
         Include="$(MSBuildThisFileDirectory)**\Xbim.Geometry.Engine32.dll" >
@@ -27,7 +27,7 @@
     </XbimInteropFiles>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(Platform)' == 'x64'">
+  <ItemGroup Condition=" '$(Platform)' == 'x64' OR '$(Platform)' == 'AnyCPU'">
     <XbimInteropFiles Condition="'$(MSBuildThisFileDirectory)' != '' And
                                    HasTrailingSlash('$(MSBuildThisFileDirectory)')"
         Include="$(MSBuildThisFileDirectory)**\Xbim.Geometry.Engine64.dll" >
@@ -55,6 +55,9 @@
         NOTE: Copy "Xbim.Geometry.Enginexx.dll" and all related files, for every
               architecture that we support, to the build output directory.
     -->
+    <Message Text="Copying Geometry Engine files @(XbimInteropFiles)." Importance="high" />
+    <Message Text="Copying Geometry Engines to bin directory $(OutputPath)$(XBimCustomBinPath)." Importance="high" />
+    
     <Copy SourceFiles="@(XbimInteropFiles)"
           DestinationFiles="@(XbimInteropFiles -> '$(OutputPath)%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>

--- a/Xbim.Geometry.Engine.Interop.targets
+++ b/Xbim.Geometry.Engine.Interop.targets
@@ -15,7 +15,7 @@
   ******************************************************************************
   -->
 
-  <ItemGroup Condition=" '$(Platform)' == 'x86'">
+  <ItemGroup Condition=" '$(Platform)' == 'x86' OR '$(Platform)' == 'AnyCPU'">
     <XbimInteropFiles Condition="'$(MSBuildThisFileDirectory)' != '' And
                                    HasTrailingSlash('$(MSBuildThisFileDirectory)')"
         Include="$(MSBuildThisFileDirectory)\Xbim.Geometry.Engine32.dll" >
@@ -26,8 +26,8 @@
       <FileType>Assembly</FileType>
     </XbimInteropFiles>
   </ItemGroup>
-  
-  <ItemGroup Condition=" '$(Platform)' == 'x64'">
+
+  <ItemGroup Condition=" '$(Platform)' == 'x64' OR '$(Platform)' == 'AnyCPU'">
     <XbimInteropFiles Condition="'$(MSBuildThisFileDirectory)' != '' And
                                    HasTrailingSlash('$(MSBuildThisFileDirectory)')"
         Include="$(MSBuildThisFileDirectory)\Xbim.Geometry.Engine64.dll" >

--- a/test.runsettings
+++ b/test.runsettings
@@ -7,6 +7,9 @@
     <TargetFrameworkVersion>.NETFramework,Version=v4.7</TargetFrameworkVersion>
 
   </RunConfiguration>
+  <MSTestV2>
+    <DeployTestSourceDependencies>false</DeployTestSourceDependencies>
+  </MSTestV2>
   <DataCollectionRunSettings>
     <DataCollectors>
       <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">


### PR DESCRIPTION
Please uncomment try catch scope in function
IXbimGeometryObject^ Xbim Geometry Creator::Create
and in second catch replace throwing of new Exception just by log. If it not make any problem.

If is IFC file little bit wrong this causes that the whole file to not load. It is because that exception is bubbling in to XbimModel Context.CreateContext() where can be caught but that is too late.

Version 4.0 of Xbim explorer can load this type of file.
But current version of expolorer 5.1 crashes.