### PR TITLE
filter out points that are collinear

### DIFF
--- a/Xbim.Geometry.Engine/XbimWire.h
+++ b/Xbim.Geometry.Engine/XbimWire.h
@@ -75,7 +75,8 @@ namespace Xbim
 			bool AreEdgesC1(const TopoDS_Edge& e1, const TopoDS_Edge& e2, double precision, double angularTolerance);
 			bool SortEdgesForWire(const NCollection_Vector<TopoDS_Edge>& oldedges, NCollection_Vector<TopoDS_Edge>& newedges, NCollection_Vector<TopoDS_Edge>& notTaken, double tol, bool *pClosed, double* pMaxGap);
 			int  GetMatchTwoPntsPair(const gp_Pnt& b1, const gp_Pnt& e1, const gp_Pnt& b2, const gp_Pnt& e2, double& minDis, double& otherDis);
-			
+			//check three points are collinear
+			bool IsCollinear(const gp_Pnt& prePoint, const gp_Pnt& currentPoint, const gp_Pnt& nextPoint);
 			
 		public:
 			static gp_Dir NormalDir(const TopoDS_Wire& wire);


### PR DESCRIPTION
for extruded solid, some points of its profile are collinear, and it cause generate one more face. This ifc file is exported by Revit, it should be Revit's problem.

#172= IFCCARTESIANPOINT((3062.13203435597,-150.));
#174= IFCCARTESIANPOINT((3362.13203435597,150.));
#176= IFCCARTESIANPOINT((2937.86796564404,150.));
#178= IFCCARTESIANPOINT((0.,150.));
#180= IFCCARTESIANPOINT((0.,-150.));
#182= IFCPOLYLINE((#172,#174,#176,#178,#180,#172));
#184= IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#182);
#187= IFCAXIS2PLACEMENT3D(#6,$,$);
#188= IFCEXTRUDEDAREASOLID(#184,#187,#20,3000.);