### PR TITLE
Fix premature garbage collection of objects holding native resources (issue #370)

### DIFF
--- a/Xbim.Geometry.Engine/XbimEdge.cpp
+++ b/Xbim.Geometry.Engine/XbimEdge.cpp
@@ -999,6 +999,8 @@ namespace Xbim
 				ShapeFix_ShapeTolerance FTol;
 				FTol.LimitTolerance(*pEdge, curve->Model->ModelFactors->Precision);
 			}
+
+			GC::KeepAlive(xbimCurve);
 		}
 
 		void XbimEdge::Init(IIfcProfileDef^ profile, ILogger^ logger)

--- a/Xbim.Geometry.Engine/XbimEdge.cpp
+++ b/Xbim.Geometry.Engine/XbimEdge.cpp
@@ -649,7 +649,7 @@ namespace Xbim
 					}
 
 					Handle(TColGeom_HArray1OfBSplineCurve)  concatcurve;     //array of the concatenated curves
-					Handle(TColStd_HArray1OfInteger)        ArrayOfIndices;  //array of the remining Vertex
+					Handle(TColStd_HArray1OfInteger)        ArrayOfIndices;  //array of the remaining Vertex
 					GeomConvert::ConcatC1(tab,
 						tabtolvertex,
 						ArrayOfIndices,
@@ -699,7 +699,7 @@ namespace Xbim
 								const Standard_Real aTol = BRep_Tool::Tolerance(aVtx);
 
 								if (aPFirst.IsEqual(aPnt, aTol)) {
-									// The coinsident vertex is found.
+									// The coincident vertex is found.
 									FirstVertex = aVtx;
 									LastVertex = aVtx;
 									FirstVertex.Orientation(TopAbs_FORWARD);
@@ -809,7 +809,7 @@ namespace Xbim
 			// If one is null, but not both, return false.
 			if (((Object^)left == nullptr) || ((Object^)right == nullptr))
 				return false;
-			//this edge comparer does not conseider orientation
+			//this edge comparer does not consider orientation
 			return  ((const TopoDS_Edge&)left).IsSame(right) == Standard_True;
 
 		}

--- a/Xbim.Geometry.Engine/XbimSolid.cpp
+++ b/Xbim.Geometry.Engine/XbimSolid.cpp
@@ -835,7 +835,7 @@ namespace Xbim
 				}
 				GC::KeepAlive(faceStart);
 				GC::KeepAlive(faceEnd);
-
+				GC::KeepAlive(sweep);
 			}
 		}
 
@@ -1041,7 +1041,7 @@ namespace Xbim
 					return;
 				}
 				GC::KeepAlive(faceStart);
-
+				GC::KeepAlive(sweep);
 			}
 			XbimGeometryCreator::LogInfo(logger, repItem, "Invalid extrusion, depth must be >0 and faces must be correctly defined");
 			//if it has failed we will have a null solid
@@ -1206,6 +1206,7 @@ namespace Xbim
 					*pSolid = outerShell;
 					pSolid->Closed(Standard_True);
 					GC::KeepAlive(crossSections);
+					GC::KeepAlive(sweep);
 					ShapeFix_ShapeTolerance tolFixer;
 					tolFixer.LimitTolerance(*pSolid, repItem->Model->ModelFactors->Precision);
 					return;
@@ -1350,6 +1351,8 @@ namespace Xbim
 				//half space solids are only used in booleans, set the face tolerance the millimeter precision we require
 				ShapeFix_ShapeTolerance tolFixer;
 				tolFixer.LimitTolerance(*pSolid, hs->Model->ModelFactors->Precision * XbimGeometryCreator::FuzzyFactor);
+
+				GC::KeepAlive(face);
 			}
 		}
 
@@ -1417,6 +1420,8 @@ namespace Xbim
 			tolFixer.LimitTolerance(polyBoundary, pbhs->Model->ModelFactors->Precision);
 			// we have to use 1e8 as the max extrusion as the common boolean op times out on values greater than this, probably an extrema issue in booleans
 			TopoDS_Shape substractionBody = BRepPrimAPI_MakePrism(BRepBuilderAPI_MakeFace(polyBoundary), gp_Vec(0, 0, 1e8));
+			GC::KeepAlive(polyBoundary);
+
 			//find point inside the material
 			gp_Pnt pnt = pln.Location().Translated(pbhs->AgreementFlag ? -pln.Axis().Direction() : pln.Axis().Direction());
 

--- a/Xbim.Geometry.Engine/XbimSolid.cpp
+++ b/Xbim.Geometry.Engine/XbimSolid.cpp
@@ -1399,7 +1399,7 @@ namespace Xbim
 			gp_Ax3 ax3 = XbimConvert::ToAx3(surface->Position);
 			gp_Pln pln(ax3);
 
-			//build the substraction body
+			//build the subtraction body
 			gp_Dir dir(pbhs->Position->P[2].X, pbhs->Position->P[2].Y, pbhs->Position->P[2].Z);
 			XbimWire^ polyBoundary = gcnew XbimWire(pbhs->PolygonalBoundary, logger, XbimConstraints::Closed | XbimConstraints::NotSelfIntersecting);
 
@@ -1514,7 +1514,7 @@ namespace Xbim
 			{
 				if (!sweep->FilletAll((double)polygonal->FilletRadius.Value))
 				{
-					XbimGeometryCreator::LogWarning(logger, repItem, "Sweep could not be corectly filleted");
+					XbimGeometryCreator::LogWarning(logger, repItem, "Sweep could not be correctly filleted");
 					transitionMode = BRepBuilderAPI_TransitionMode::BRepBuilderAPI_RightCorner; //revert to non continuous mode
 				}
 			}
@@ -1540,7 +1540,7 @@ namespace Xbim
 
 			//If the transitions between consecutive segments of the Directrix are not tangent continuous, the resulting solid is created by a miter at half angle between the two segments.
 			//this will be the case for a polyline as each segment is not tangent continuous
-			//composite urves will be tangent continuous
+			//composite curves will be tangent continuous
 			try
 			{
 				//form the shape to sweep, the centre of the circles must be at the start of the directrix
@@ -1641,7 +1641,7 @@ namespace Xbim
 		// comments on the interpretation of the params are found here:
 			// https://sourceforge.net/p/ifcexporter/discussion/general/thread/7cc44b69/?limit=25
 			// if the directix is:
-			// - a line, just use the lenght
+			// - a line, just use the length
 			// - a IFCCOMPOSITECURVE then the parameter 
 			//   for each line add 0 to 1
 			//   for each arc add the angle
@@ -1656,7 +1656,7 @@ namespace Xbim
 			}
 			BRepAdaptor_CompCurve cc(wire, Standard_True);
 
-			//if we have a trimmed curve we need to get the basis curve for correct parameterisation
+			//if we have a trimmed curve we need to get the basis curve for correct parameterization
 
 			IIfcCurve^ basisCurve = directrix;
 			while (dynamic_cast<IIfcTrimmedCurve^>(basisCurve))
@@ -1710,14 +1710,14 @@ namespace Xbim
 					{
 						double ratio = Math::Min(startPar / segValue, 1.0);
 						startPar -= ratio * segValue; // reduce the outstanding amount (since it's been accounted for in the segment just processed)
-						occStart += ratio * wireLen; // progress the occ amount by the ratio of the lenght
+						occStart += ratio * wireLen; // progress the occ amount by the ratio of the length
 					}
 
 					if (endPar > 0)
 					{
 						double ratio = Math::Min(endPar / segValue, 1.0);
 						endPar -= ratio * segValue; // reduce the outstanding amount (since it's been accounted for in the segment just processed)
-						occEnd += ratio * wireLen; // progress the occ amount by the ratio of the lenght
+						occEnd += ratio * wireLen; // progress the occ amount by the ratio of the length
 					}
 				}
 				double precision = directrix->Model->ModelFactors->Precision;

--- a/Xbim.Geometry.Engine/XbimSolid.cpp
+++ b/Xbim.Geometry.Engine/XbimSolid.cpp
@@ -1525,6 +1525,7 @@ namespace Xbim
 					XbimGeometryCreator::LogWarning(logger, repItem, "Could not fully construct IfcSweptDiskSolid: " + err);
 			}
 
+			GC::KeepAlive(sweep);
 		}
 
 		//if inner radius is not required it has a value of -1


### PR DESCRIPTION
Fixes several cases of `AccessViolationException`, caused by premature garbage collection of managed objects containing references to unmanaged resources which were still in use by native code.