### PR TITLE
Fix for issue #338

### DIFF
--- a/Xbim.Geometry.Engine/XbimFace.cpp
+++ b/Xbim.Geometry.Engine/XbimFace.cpp
@@ -1798,35 +1798,37 @@ namespace Xbim
 					//trim 1 and trim 2 will be cartesian points
 					IIfcCartesianPoint^ trim1 = dynamic_cast<IIfcCartesianPoint^>(Enumerable::FirstOrDefault(tc->Trim1));
 					IIfcCartesianPoint^ trim2 = dynamic_cast<IIfcCartesianPoint^>(Enumerable::FirstOrDefault(tc->Trim2));
-					gp_Pnt p1 = XbimConvert::GetPoint3d(trim1);
-					gp_Pnt p2 = XbimConvert::GetPoint3d(trim2);
-					//there are two solutions A, B
-					//calc solution A
-					double radsq = circle->Radius * circle->Radius;
-					double qX = Math::Sqrt(((p2.X() - p1.X()) * (p2.X() - p1.X())) + ((p2.Y() - p1.Y()) * (p2.Y() - p1.Y())));
-					double x3 = (p1.X() + p2.X()) / 2;
-					double centreX = x3 - Math::Sqrt(radsq - ((qX / 2) * (qX / 2))) * ((p1.Y() - p2.Y()) / qX);
 
-					double qY = Math::Sqrt(((p2.X() - p1.X()) * (p2.X() - p1.X())) + ((p2.Y() - p1.Y()) * (p2.Y() - p1.Y())));
+					if (trim1 != nullptr && trim2 != nullptr) {
 
-					double y3 = (p1.Y() + p2.Y()) / 2;
+						gp_Pnt p1 = XbimConvert::GetPoint3d(trim1);
+						gp_Pnt p2 = XbimConvert::GetPoint3d(trim2);
 
-					double centreY = y3 - Math::Sqrt(radsq - ((qY / 2) * (qY / 2))) * ((p2.X() - p1.X()) / qY);
+						//there are two solutions A, B
+						//calc solution A
+						double radsq = circle->Radius * circle->Radius;
+						double qX = Math::Sqrt(((p2.X() - p1.X()) * (p2.X() - p1.X())) + ((p2.Y() - p1.Y()) * (p2.Y() - p1.Y())));
+						double x3 = (p1.X() + p2.X()) / 2;
+						double centreX = x3 - Math::Sqrt(radsq - ((qX / 2) * (qX / 2))) * ((p1.Y() - p2.Y()) / qX);
 
+						double qY = Math::Sqrt(((p2.X() - p1.X()) * (p2.X() - p1.X())) + ((p2.Y() - p1.Y()) * (p2.Y() - p1.Y())));
 
+						double y3 = (p1.Y() + p2.Y()) / 2;
 
-					ITransaction^ txn = sLin->Model->BeginTransaction("Fix Centre");
+						double centreY = y3 - Math::Sqrt(radsq - ((qY / 2) * (qY / 2))) * ((p2.X() - p1.X()) / qY);
 
+						ITransaction^ txn = sLin->Model->BeginTransaction("Fix Centre");
 
-					IIfcPlacement^ p = dynamic_cast<IIfcPlacement^>(circle->Position);
+						IIfcPlacement^ p = dynamic_cast<IIfcPlacement^>(circle->Position);
 
-					p->Location->Coordinates[0] = centreX;
-					p->Location->Coordinates[1] = centreY;
-					p->Location->Coordinates[2] = 0;
+						p->Location->Coordinates[0] = centreX;
+						p->Location->Coordinates[1] = centreY;
+						p->Location->Coordinates[2] = 0;
 
-					xbasisEdge1 = gcnew XbimEdge(sLin->SweptCurve, logger);
-					txn->RollBack();
-					isFixed = true;
+						xbasisEdge1 = gcnew XbimEdge(sLin->SweptCurve, logger);
+						txn->RollBack();
+						isFixed = true;
+					}
 				}
 
 


### PR DESCRIPTION
Can you tell me if this fix is ok for the regression bug #338 ? I simply added a "null check" after the casting to avoid an exception than cause the end of the creation process. So, if the Trim1 and Trim2 of the Trimmed Curve are not Cartesian Points, it's avoid the computation of a new position for the curve circle. 