### PR TITLE
Fixed regression in processing IfcEdgeCurve with same EdgeStart and EdgeEnd

### DIFF
--- a/Xbim.Geometry.Engine/XbimCompound.cpp
+++ b/Xbim.Geometry.Engine/XbimCompound.cpp
@@ -830,6 +830,17 @@ namespace Xbim
 											builder.UpdateVertex(endVertex, trim2Tolerance);
 
 										BRepBuilderAPI_MakeEdge edgeMaker(sharedEdgeGeom, startVertex, endVertex, trimParam1, trimParam2);
+										/// in current official IFC documentation, the start and end can be the same, hence resulting the curve not getting trimmed
+										/// see https://standards.buildingsmart.org/IFC/RELEASE/IFC4/ADD2_TC1/HTML/schema/ifctopologyresource/lexical/ifcedge.htm
+										/// in "Attribute Definitions", for param 2 "EdgeEnd": The same vertex can be used for both EdgeStart and EdgeEnd.
+										/// this appears to be a regression comparing to older versions of this function (InitAdvancedFaces)
+										/// which uses XbimEdge to do the trimming and handled this situation
+										/// 
+										/// the fix: here we simply do not pass the trimming params to the edgeMaker and everything goes one just fine
+										if (foundP1 && foundP2 && trimParam1 == trimParam2)
+										{
+											edgeMaker = BRepBuilderAPI_MakeEdge(sharedEdgeGeom);
+										}
 										if (!edgeMaker.IsDone())
 										{
 											BRepBuilderAPI_EdgeError err = edgeMaker.Error();


### PR DESCRIPTION
see https://standards.buildingsmart.org/IFC/RELEASE/IFC4/ADD2_TC1/HTML/schema/ifctopologyresource/lexical/ifcedge.htm
in "Attribute Definitions", for param 2 "EdgeEnd": The same vertex can be used for both EdgeStart and EdgeEnd.
This appears to be a regression comparing to older versions of this function (InitAdvancedFaces) which uses XbimEdge to do the trimming and handled this situation.
![comparing-ifcvalve-using-ifcedgecurve-with-same-start-and-end](https://github.com/xBimTeam/XbimGeometry/assets/61967085/397833c6-d1e4-4ed3-9ac1-6ff2c9dd18d6)
