### PR TITLE
Fixed transparency of IIfcSurfaceStyleShading set to opaque when transparency data is not given

### DIFF
--- a/Xbim.Geometry.Engine/Visual/XbimShapeColour.cpp
+++ b/Xbim.Geometry.Engine/Visual/XbimShapeColour.cpp
@@ -74,7 +74,7 @@ namespace Xbim
 					}
 					else if (sr != nullptr)
 						Shininess = System::Convert::ToSingle(sr->Value);
-					Transparency = rendering->Transparency.HasValue ? (float)rendering->Transparency.Value : 1.0f;
+					Transparency = rendering->Transparency.HasValue ? (float)rendering->Transparency.Value : 0.0f;
 
 					return;
 				}
@@ -82,7 +82,7 @@ namespace Xbim
 				{
 					IIfcColourRgb^ surface = shading->SurfaceColour;
 					AmbientColor = gcnew ColourRGB(surface->Red, surface->Green, surface->Blue);
-					Transparency = shading->Transparency.HasValue ? (float)shading->Transparency.Value : 1.0f;
+					Transparency = shading->Transparency.HasValue ? (float)shading->Transparency.Value : 0.0f;
 
 					return;
 				}


### PR DESCRIPTION
The IFC specification assumes the color is opaque when the transparency is not given. (Opposite alpha channel)
 
The transparency field specifies how "clear" an object is, with 1.0 being completely transparent, and 0.0 completely opaque. If not given, the value 0.0 (opaque) is assumed.

NOTE  The definition of 1 being transparent and 0 being opaque is the opposite of the definition in alpha channels, where 0.0 is completely transparent and 1.0 is completely opaque. This definition is due to upward compatibility to previous versions of this standard in different to the definition in IfcIndexedColourMap.

From: [IfcSurfaceStyleShading](https://standards.buildingsmart.org/IFC/RELEASE/IFC4/ADD2/HTML/schema/ifcpresentationappearanceresource/lexical/ifcsurfacestyleshading.htm)

