### PR TITLE
Removed crashing case for XbimPlacementTree ctor

### DIFF
--- a/Xbim.ModelGeometry.Scene/Xbim3DModelContext.cs
+++ b/Xbim.ModelGeometry.Scene/Xbim3DModelContext.cs
@@ -259,8 +259,7 @@ namespace Xbim.ModelGeometry.Scene
             {
                 try
                 {
-
-                    PlacementTree = new XbimPlacementTree(Model, adjustWcs);
+                    PlacementTree = new XbimPlacementTree(Model, adjustWcs, _modelContext._logger);
                     GeometryShapeLookup = new ConcurrentDictionary<int, int>();
                     MapGeometryReferences = new ConcurrentDictionary<int, List<GeometryReference>>();
                     MapTransforms = new ConcurrentDictionary<int, XbimMatrix3D>();


### PR DESCRIPTION
Changed the handling of missing placements so that models can be opened even with missing placement implementations.
Errors are notified in the log.