### PR TITLE
fix for single-file deployment

### DIFF
--- a/Xbim.Geometry.Engine.Interop/Extensions/ServiceCollectionExtensions.cs
+++ b/Xbim.Geometry.Engine.Interop/Extensions/ServiceCollectionExtensions.cs
@@ -120,7 +120,8 @@ namespace Xbim.Common.Configuration
 #if NETFRAMEWORK
             var codepath = new Uri(assembly.CodeBase);
 #else
-            var codepath = new Uri(assembly.Location);
+            var location = assembly.Location;
+            var codepath = new Uri(String.IsNullOrEmpty(location) ? AppContext.BaseDirectory : location);
 #endif
             return LoadDll(codepath.LocalPath);
         });


### PR DESCRIPTION
When using [single-file deployment](https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli#api-incompatibility) the `Assembly.Location` returns an empty string. To resolve this issue we use the recommended workaround `AppContext.BaseDirectory`.