### PR TITLE
Added missing LogInfo argument - Issue 492

### DIFF
--- a/Xbim.Geometry.Engine/XbimSolidSet.cpp
+++ b/Xbim.Geometry.Engine/XbimSolidSet.cpp
@@ -927,7 +927,7 @@ namespace Xbim
 				}
 				if (profileCount == 1)
 				{
-					XbimGeometryCreator::LogInfo(logger, repItem, "Invalid number of profiles in IIfcCompositeProfileDef #{0}. It must be 2 or more. A single Profile has been used");
+					XbimGeometryCreator::LogInfo(logger, repItem, "Invalid number of profiles in IIfcCompositeProfileDef #{0}. It must be 2 or more. A single Profile has been used", compProfile->EntityLabel);
 					XbimSolid^ s = gcnew XbimSolid(repItem, logger);
 					if (s->IsValid)
 					{


### PR DESCRIPTION
When the composite profile consists of only one profile, a log warning is issued. However the LogInfo format message is missing an argument, which results in an exception being thrown and the XbimSolid not being generated.