### PR TITLE
Replace std::mutex by std::shared_mutex

### DIFF
--- a/Xbim.Geometry.Engine.Tests/MeshSimplificationTests.cs
+++ b/Xbim.Geometry.Engine.Tests/MeshSimplificationTests.cs
@@ -93,6 +93,6 @@ namespace Xbim.Geometry.Engine.Tests
         public long SizeAfter { get; set; }
         public uint TrianglesBefore { get; set; }
         public uint TrianglesAfter { get; set; }
-        public string FileName { get; set; }
+        public string FileName { get; set; } = string.Empty;
     }
 }

--- a/Xbim.Geometry.Engine.Tests/MoqCreators/MoqDefaultBehaviourProvider.cs
+++ b/Xbim.Geometry.Engine.Tests/MoqCreators/MoqDefaultBehaviourProvider.cs
@@ -22,7 +22,7 @@ namespace Xbim.Geometry.Engine.Tests
                 Type lType = typeof(ItemListMoq<>);
                 var genType = type.GetGenericArguments()[0];
                 Type constructed = lType.MakeGenericType(genType);
-                return Activator.CreateInstance(constructed);
+                return Activator.CreateInstance(constructed)!;
             }
             );
             //base.Register(typeof(ExpressType), (type, mock) =>

--- a/Xbim.Geometry.Engine.Tests/TessellatorTests.cs
+++ b/Xbim.Geometry.Engine.Tests/TessellatorTests.cs
@@ -56,7 +56,7 @@ namespace Xbim.Geometry.Engine.Tests
             using (var model = IfcStore.Open("TestFiles\\Ifc4TestFiles\\polygonal-face-tessellation.ifc"))
             {
                 var xbimTessellator = new XbimTessellator(model, tp);
-                XbimShapeGeometry shapeGeom = null;
+                XbimShapeGeometry shapeGeom;
 
                 var shape = model.Instances.FirstOrDefault<IIfcPolygonalFaceSet>();
                 shapeGeom = xbimTessellator.Mesh(shape);
@@ -71,7 +71,7 @@ namespace Xbim.Geometry.Engine.Tests
             using (var model = IfcStore.Open("TestFiles\\IfcExamples\\Roof-01_BCAD.ifc"))
             {
                 var xbimTessellator = new XbimTessellator(model, tp);
-                XbimShapeGeometry shapeGeom = null;
+                XbimShapeGeometry shapeGeom;
 
                 var shape = model.Instances[1192] as IIfcGeometricRepresentationItem;
                 shapeGeom = xbimTessellator.Mesh(shape);
@@ -86,7 +86,7 @@ namespace Xbim.Geometry.Engine.Tests
             using (var model = IfcStore.Open("TestFiles\\Ifc4TestFiles\\IfcTriangulatedFaceSet.ifc"))
             {
                 var xbimTessellator = new XbimTessellator(model, tp);
-                XbimShapeGeometry shapeGeom = null;
+                XbimShapeGeometry shapeGeom;
 
                 var shape = model.Instances[48] as IIfcGeometricRepresentationItem;
                 shapeGeom = xbimTessellator.Mesh(shape);

--- a/Xbim.Geometry.Engine/Factories/WireFactory.cpp
+++ b/Xbim.Geometry.Engine/Factories/WireFactory.cpp
@@ -368,10 +368,10 @@ namespace Xbim
 
 			struct WireFactoryNativeStatics
 			{
-				static std::mutex execNativeMutex;
+				static std::shared_mutex execNativeMutex;
 			};
 
-			std::mutex WireFactoryNativeStatics::execNativeMutex;
+			std::shared_mutex WireFactoryNativeStatics::execNativeMutex;
 			TopoDS_Wire WireFactory::BuildWire(IIfcIndexedPolyCurve^ ifcIndexedPolyCurve, bool asSingleEdge)
 			{
 				if (asSingleEdge)
@@ -386,7 +386,7 @@ namespace Xbim
 				{
 					if (2 == (int)ifcIndexedPolyCurve->Dim)
 					{
-						std::lock_guard<std::mutex> lock(WireFactoryNativeStatics::execNativeMutex);
+						std::lock_guard<std::shared_mutex> lock(WireFactoryNativeStatics::execNativeMutex);
 						TColGeom2d_SequenceOfBoundedCurve segments;
 						CURVE_FACTORY->BuildIndexPolyCurveSegments2d(ifcIndexedPolyCurve, segments);
 						if (segments.Length() == 0) 

--- a/Xbim.Geometry.Engine/Services/Caching/Cache.h
+++ b/Xbim.Geometry.Engine/Services/Caching/Cache.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <unordered_map>
-#include <mutex>
+#include <shared_mutex>
 #include <optional>
 #include <Standard_Handle.hxx>
 #include <TopoDS_Shape.hxx>
@@ -11,17 +11,17 @@ class Cache {
 public:
 
     void Insert(int id, const Handle(Standard_Transient)& value) {
-        std::lock_guard<std::mutex> lock(_mutex);
+        std::lock_guard<std::shared_mutex> lock(_mutex);
         _cache[id] = value;
     }
 
     void InsertShape(int id, const TopoDS_Shape& value) {
-        std::lock_guard<std::mutex> lock(_mutex);
+        std::lock_guard<std::shared_mutex> lock(_mutex);
         _shapeCache[id] = value;
     }
 
     std::optional<Handle(Standard_Transient)> Get(int id) const {
-        std::lock_guard<std::mutex> lock(_mutex);
+        std::lock_guard<std::shared_mutex> lock(_mutex);
         auto it = _cache.find(id);
         if (it != _cache.end()) {
             return it->second;
@@ -30,7 +30,7 @@ public:
     }
 
     std::optional<TopoDS_Shape> GetShape(int id) const {
-        std::lock_guard<std::mutex> lock(_mutex);
+        std::lock_guard<std::shared_mutex> lock(_mutex);
         auto it = _shapeCache.find(id);
         if (it != _shapeCache.end()) {
             return it->second;
@@ -39,33 +39,33 @@ public:
     }
 
     void Remove(int id) {
-        std::lock_guard<std::mutex> lock(_mutex);
+        std::lock_guard<std::shared_mutex> lock(_mutex);
         _cache.erase(id);
     }
 
     void RemoveShape(int id) {
-        std::lock_guard<std::mutex> lock(_mutex);
+        std::lock_guard<std::shared_mutex> lock(_mutex);
         _shapeCache.erase(id);
     }
 
     bool Contains(int id) const {
-        std::lock_guard<std::mutex> lock(_mutex);
+        std::lock_guard<std::shared_mutex> lock(_mutex);
         return _cache.find(id) != _cache.end();
     }
 
     bool ContainsShape(int id) const {
-        std::lock_guard<std::mutex> lock(_mutex);
+        std::lock_guard<std::shared_mutex> lock(_mutex);
         return _shapeCache.find(id) != _shapeCache.end();
     }
 
     void Clear() {
-        std::lock_guard<std::mutex> lock(_mutex);
+        std::lock_guard<std::shared_mutex> lock(_mutex);
         _cache.clear();
         _shapeCache.clear();
     }
 
 private:
-    mutable std::mutex _mutex;
+    mutable std::shared_mutex _mutex;
     std::unordered_map<int, Handle(Standard_Transient)> _cache;
     std::unordered_map<int, TopoDS_Shape> _shapeCache;
 };


### PR DESCRIPTION
Replacing `std::mutex` by `std::shared_mutex` avoids System.AccessViolationException on a virtual machine (Hyper-V, Guest VM Windows 10, Windows 11, Server 2016, Server 2022 etc.) when running `Xbim3DModelContext.CreateContext`.

See comments after Sep 20, 2025 in [Multi-Threading Crash (AccessViolationException) #489](https://github.com/xBimTeam/XbimGeometry/issues/489).

Test cases show no regression.
