### PR TITLE
Fix race condition in BuildCurve causing false "previously failed" exceptions during concurrent IfcGradientCurve processing

### DIFF
--- a/Xbim.Geometry.Engine/Factories/CurveFactory.h
+++ b/Xbim.Geometry.Engine/Factories/CurveFactory.h
@@ -24,6 +24,8 @@
 #include "../BRep/OccExtensions/Curves/Geom_SegmentedReferenceCurve.h"
 
 
+using namespace System::Collections::Concurrent;
+using namespace System::Threading;
 using namespace Xbim::Ifc4::MeasureResource;
 
 namespace Xbim
@@ -38,7 +40,6 @@ namespace Xbim
 			public:
 				CurveFactory(Xbim::Geometry::Services::ModelGeometryService^ modelService) : FactoryBase(modelService, new NCurveFactory())
 				{
-					attemptedEntityLabels = gcnew HashSet<int>();
 				}
 
 #pragma region Top level abstraction for building any XCurve
@@ -70,7 +71,11 @@ namespace Xbim
 				std::vector<std::pair<Handle(Geom2d_Curve), TopLoc_Location>> ProcessSegments(Ifc4x3::GeometryResource::IfcSegmentedReferenceCurve^ ifcSegmentedReferenceCurve);
 				Handle(Geom2d_Curve) TransformCurveWithLocation(const Handle(Geom2d_Curve)& curve, IIfcAxis2Placement2D^ placement);
 				Handle(Geom2d_Curve) TransformCurveWithLocation(const Handle(Geom2d_Curve)& curve, IIfcAxis2Placement3D^ placement);
-				HashSet<int>^ attemptedEntityLabels; // Tracks attempted EntityLabels
+				static ConcurrentDictionary<int, SemaphoreSlim^>^ _inFlightCurves =
+					gcnew ConcurrentDictionary<int, SemaphoreSlim^>();
+
+				static ConcurrentDictionary<int, char>^ _failedCurves =
+					gcnew ConcurrentDictionary<int, char>();
 
 #pragma region Build Curves (3D)
 			public:

--- a/Xbim.Geometry.Engine/Factories/Unmanaged/NCurveFactory.cpp
+++ b/Xbim.Geometry.Engine/Factories/Unmanaged/NCurveFactory.cpp
@@ -319,7 +319,7 @@ Handle(Geom2d_BSplineCurve) NCurveFactory::BuildCompositeCurve2d(const TColGeom2
 				toAdd = curveBuilder.Curve();
 			}
 			else if (IsConicLike(curve)) {
-				// This covers raw conics AND trimmed/offset conics.
+				// This covers raw conics and trimmed/offset conics.
 				toAdd = ApproximateByArcLength(curve, first, last, tolerance, 8, GeomAbs_CN);
 			}
 			else if (!compositeConverter.Add(curve, tolerance, false))


### PR DESCRIPTION
Fixes #561 